### PR TITLE
Add new label `type.UiFlaw`

### DIFF
--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -63,6 +63,8 @@ const FEATURE_FLAW_DEFINITION =
   'of the project.</p>';
 const DOCUMENTATION_BUG_DEFINITION =
   '<p>A flaw in the documentation ' + '<span style="color:grey;">e.g., a missing step, a wrong instruction, typos</span></p>';
+const UI_FLAW_DEFINITION = 
+  '<p>A flaw in the user interface that inconveniences users <spans style="color:grey;">e.g. broken buttons, poor text visibility</span></p>';
 
 const ACCEPTED_DEFINITION = '<p>You accept it as a bug.</p>';
 const NOT_IN_SCOPE_DEFINITION =
@@ -83,6 +85,7 @@ export const LABEL_DEFINITIONS = {
   typeFunctionalityBug: FUNCTIONALITY_BUG_DEFINITION,
   typeFeatureFlaw: FEATURE_FLAW_DEFINITION,
   typeDocumentationBug: DOCUMENTATION_BUG_DEFINITION,
+  typeUiFlaw: UI_FLAW_DEFINITION,
   responseAccepted: ACCEPTED_DEFINITION,
   responseNotInScope: NOT_IN_SCOPE_DEFINITION,
   responseRejected: REJECTED_DEFINITION,
@@ -101,7 +104,8 @@ const REQUIRED_LABELS = {
   type: {
     DocumentationBug: new Label('type', 'DocumentationBug', COLOR_PURPLE_LIGHT, DOCUMENTATION_BUG_DEFINITION),
     FeatureFlaw: new Label('type', 'FeatureFlaw', COLOR_PURPLE_LIGHT, FEATURE_FLAW_DEFINITION),
-    FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION)
+    FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION),
+    UiFlaw: new Label('type', 'UiFlaw', COLOR_PURPLE_LIGHT, UI_FLAW_DEFINITION)
   },
   response: {
     Accepted: new Label('response', 'Accepted', COLOR_GREEN, ACCEPTED_DEFINITION),

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -105,7 +105,7 @@ const REQUIRED_LABELS = {
     DocumentationBug: new Label('type', 'DocumentationBug', COLOR_PURPLE_LIGHT, DOCUMENTATION_BUG_DEFINITION),
     FeatureFlaw: new Label('type', 'FeatureFlaw', COLOR_PURPLE_LIGHT, FEATURE_FLAW_DEFINITION),
     FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION),
-    UiFlaw: new Label('type', 'UiFlaw', COLOR_PURPLE_LIGHT, UI_FLAW_DEFINITION)
+    UiFlaw: new Label('type', 'UIFlaw', COLOR_PURPLE_LIGHT, UI_FLAW_DEFINITION)
   },
   response: {
     Accepted: new Label('response', 'Accepted', COLOR_GREEN, ACCEPTED_DEFINITION),


### PR DESCRIPTION
> [Sample task from CATcher DG]

There are only 3 types of bugs in CATcher: `type.DocumentationBug`, `type.FeatureFlaw` and `type.FunctionalityBug`.

Let's add a fourth one, `type.UiFlaw` to understsand the backend.

![image](https://github.com/chia-yh/CATcher/assets/105497890/2784efe6-d3a3-4600-8f1b-c05de259b441)
