### PR TITLE
Delete labels that are not in use

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -286,6 +286,14 @@ export class GithubService {
     octokit.issues.updateLabel({ owner: ORG_NAME, repo: REPO, name: labelName, current_name: labelName, color: labelColor });
   }
 
+  /**
+   * Deletes a label in the current repository.
+   * @param labelName - name of existing label
+   */
+  deleteLabel(labelName: string): void {
+    octokit.issues.deleteLabel({ owner: ORG_NAME, repo: REPO, name: labelName});
+  }
+
   closeIssue(id: number): Observable<GithubIssue> {
     return from(octokit.issues.update({ owner: ORG_NAME, repo: REPO, issue_number: id, state: 'closed' })).pipe(
       map((response: GithubResponse<GithubIssue>) => {

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -273,8 +273,7 @@ export class LabelService {
    * Ensures that the repo has the required labels.
    * Compares the actual labels in the repo with the required labels. If an required label is missing,
    * it is added to the repo. If the required label exists but the label color is not as expected,
-   * the color is updated. Does not delete actual labels that do not match required labels.
-   * i.e., the repo might have more labels than the required labels after this operation.
+   * the color is updated. Deletes labels that do not match required labels.
    * @param actualLabels: labels in the repo.
    * @param requiredLabels: required labels.
    */
@@ -295,6 +294,13 @@ export class LabelService {
         }
       } else {
         throw new Error('Unexpected error: the repo has multiple labels with the same name ' + label.getFormattedName());
+      }
+    });
+
+    actualLabels.forEach((label) => {
+      if (!(requiredLabels.some((reqLabel) => reqLabel.getFormattedName() === label.getFormattedName()))) {
+        // the label does not match required labels -> delete label
+        this.githubService.deleteLabel(label.getFormattedName());
       }
     });
   }


### PR DESCRIPTION
> [Sample task from CATcher DG]

Github automatically creates default labels on creation of a new
repository, which may not be used in CATcher. User may also have added
other labels on their own.

Let's add a feature to delete all labels not required by CATcher on
login